### PR TITLE
Fix broken reference to TensorBase::Serialize

### DIFF
--- a/tensorflow/core/framework/tensor.proto
+++ b/tensorflow/core/framework/tensor.proto
@@ -24,8 +24,8 @@ message TensorProto {
   // to represent a constant Tensor with a single value.
   int32 version_number = 3;
 
-  // Serialized content from TensorBase::Serialize() This representation can be
-  // used for all tensor types.
+  // Serialized content from Tensor::AsProtoTensorContent() This representation
+  // can be used for all tensor types.
   bytes tensor_content = 4;
 
   // Type specific representations that make it easy to create tensor protos in


### PR DESCRIPTION
I spent a few hours trying to track down this reference. Hopefully future readers won't have to!

In case anyone's curious, `TensorBase` is part of [Eigen](https://bitbucket.org/eigen/eigen/src/ce5a455b34c0a0ac3545a1497cb4a16c38ed90e8/unsupported/Eigen/CXX11/src/Tensor/TensorBase.h?at=3.3-beta1&fileviewer=file-view-default). I believe the contents of the `tensor_content` field are just packed arrays of raw floats, doubles, or whatever the value type is.
